### PR TITLE
Switch worker_process count to auto

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -2,7 +2,7 @@
 load_module /usr/local/libexec/nginx/{{ module }};
 {% endif %}{% endfor %}
 
-worker_processes 8;
+worker_processes auto;
 
 events {
     worker_connections 1024;


### PR DESCRIPTION
The worker count doesn't match perfectly every instance. The auto setting does that automatically for you.