### PR TITLE
Add support for custom log targets

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -2,6 +2,9 @@
 nginx:
   package: nginx
   security_headers: []
+  log:
+    access: /var/log/nginx/access.log
+    error: /var/log/nginx/error.log
   prefix:
     config: >-
       {%- if ansible_system == 'Linux' -%}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible
+ansible<12.0.0
 ansible-lint
 docker
 molecule<25.2.0

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -41,8 +41,8 @@ http {
     {% endif %}
     {%- endfor %}
 
-    access_log {{ nginx.prefix.log }}/access.log {{ nginx.log_format }};
-    error_log {{ nginx.prefix.log }}/error.log;
+    access_log {{ nginx.log.access }} {{ nginx.log_format }};
+    error_log {{ nginx.log.error }};
 
     resolver {{ ' '.join(nginx.nameservers) }} valid={{ nginx.nameservers_valid }} ipv6={{ nginx.nameservers_ipv6 }};
     resolver_timeout 5s;


### PR DESCRIPTION
The nginx.prefix.log variable will remain in place for backwards compatibility